### PR TITLE
Decouple HTML to PDF logic from saving functionality for improved flexibility

### DIFF
--- a/playground/app.vue
+++ b/playground/app.vue
@@ -14,6 +14,13 @@
       >
         Generate protected PDF
       </button>
+      <br>
+      <button
+        style="border-radius: 0; font-size: 20px; cursor: pointer; margin-top: 10px"
+        @click="openInWindow(pdfSection)"
+      >
+        Generate custom PDF and open in window
+      </button>
     </div>
     <div ref="pdfSection" style="width: 500px; margin: auto">
       <TestingStage />
@@ -24,6 +31,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { exportToPDF } from '#imports'
+import { htmlToPdf } from '../src/runtime/composables/htmlToPdf';
 
 const pdfSection = ref<HTMLElement | null>(null)
 
@@ -41,6 +49,24 @@ const printProtected = (HTMLElement: HTMLElement | undefined) => {
         useCORS: true
       }
     })
+}
+
+const openInWindow = async (HTMLElement: HTMLElement) => {
+  const pdf = await htmlToPdf(HTMLElement,
+    {
+      html2canvas: {
+        scale: 0.7,
+        useCORS: true
+      }
+    })
+  const totalPages = pdf.getNumberOfPages()
+  const pdfHeight = pdf.getPageHeight()
+  await pdf.html('<b>I am a custom pdf!!!</b>', {
+    x: 20,
+    y: (pdfHeight - 50) * totalPages // place in the bottom
+  })
+  const blob = pdf.output('blob')
+  window.open(URL.createObjectURL(blob), '_blank')
 }
 </script>
 

--- a/src/runtime/composables/exportToPDF.ts
+++ b/src/runtime/composables/exportToPDF.ts
@@ -1,24 +1,12 @@
-import jsPDF, { HTMLOptions, jsPDFOptions } from 'jspdf'
+import { HTMLOptions, jsPDFOptions } from 'jspdf'
+import { htmlToPdf } from './htmlToPdf'
 
 export const exportToPDF = async (
   fileName: string,
-  element?: HTMLElement,
+  element: HTMLElement,
   documentOptions?: jsPDFOptions,
-  options?: HTMLOptions
+  htmlOptions?: HTMLOptions
 ) => {
-  if (!(element instanceof HTMLElement)) {
-    throw new TypeError('usePDFExport: element is not a HTMLElement.')
-  }
-  const orientation = (element.offsetWidth > element.offsetHeight) ? 'l' : 'p'
-
-  // eslint-disable-next-line new-cap
-  const pdf = new jsPDF({
-    orientation: documentOptions?.orientation ?? orientation,
-    unit: documentOptions?.unit ?? 'px',
-    format: documentOptions?.format ?? 'A4',
-    encryption: documentOptions?.encryption
-  })
-
-  await pdf.html(element, options)
+  const pdf = await htmlToPdf(element, documentOptions, htmlOptions)
   return pdf.save(fileName)
 }

--- a/src/runtime/composables/htmlToPdf.ts
+++ b/src/runtime/composables/htmlToPdf.ts
@@ -1,0 +1,23 @@
+import jsPDF, { HTMLOptions, jsPDFOptions } from 'jspdf'
+
+export const htmlToPdf = async (
+  element: HTMLElement,
+  documentOptions?: jsPDFOptions,
+  htmlOptions?: HTMLOptions
+) => {
+  if (!(element instanceof HTMLElement)) {
+    throw new TypeError('usePDFExport: element is not a HTMLElement.')
+  }
+  const orientation = (element.offsetWidth > element.offsetHeight) ? 'l' : 'p'
+
+  // eslint-disable-next-line new-cap
+  const pdf = new jsPDF({
+    orientation: documentOptions?.orientation ?? orientation,
+    unit: documentOptions?.unit ?? 'px',
+    format: documentOptions?.format ?? 'A4',
+    encryption: documentOptions?.encryption
+  })
+
+  await pdf.html(element, htmlOptions)
+  return pdf
+}


### PR DESCRIPTION
Decouple HTML to PDF conversion logic from the saving function to enable retrieving the converted PDF result for additional manipulation, rather than direct saving.

Closes # .

Checklist:
- [ ] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [X] manually checked my feature / checking not applicable
- [ ] wrote tests / testing not applicable
- [ ] attached screenshots / screenshot not applicable
