### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,7 @@
 1. Add `@sidebase/nuxt-pdf` dependency to your project
 
 ```bash
-# Using pnpm
-pnpm add -D @sidebase/nuxt-pdf
-
-# Using yarn
-yarn add --dev @sidebase/nuxt-pdf
-
-# Using npm
-npm install --save-dev @sidebase/nuxt-pdf
+npx nuxi@latest module add nuxt-pdf
 ```
 
 2. Add `@sidebase/nuxt-pdf` to the `modules` section of `nuxt.config.ts`

--- a/docs/content/1.getting-started/2.installation.md
+++ b/docs/content/1.getting-started/2.installation.md
@@ -5,16 +5,8 @@ description: "How to install nuxt-pdf."
 # Installation
 
 To install the module begin by installing our package
-::code-group
-```bash [npm]
-npm install -D @sidebase/nuxt-pdf
+```bash
+npx nuxi@latest module add nuxt-pdf
 ```
-```bash [yarn]
-yarn add --dev @sidebase/nuxt-pdf
-```
-```bash [pnpm]
-pnpm i -D @sidebase/nuxt-pdf
-```
-::
 
 `nuxt-pdf` only requires a Nuxt 3 app to run.


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏


Checklist:
- [ ] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [ ] manually checked my feature / checking not applicable
- [ ] wrote tests / testing not applicable
- [ ] attached screenshots / screenshot not applicable
